### PR TITLE
AreTomo in streaming

### DIFF
--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -268,10 +268,9 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
         """
         self.readingOutput()
         while True:
-            listTSInput = [self._getSetOfTiltSeries().getIdSet()]
-
-            if not (self._getSetOfTiltSeries().isStreamOpen() and
-                    self.TS_read == listTSInput):
+            listTSInput = list(self._getSetOfTiltSeries().getIdSet())
+            self.info('info: {} {}'.format(self.TS_read, listTSInput))
+            if not self._getSetOfTiltSeries().isStreamOpen() and self.TS_read == listTSInput:
                 self.info('Input set closed, all items processed\n')
                 break
             for ts in self._getSetOfTiltSeries():

--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -2,7 +2,7 @@
 # *
 # * Authors:     Grigory Sharov (gsharov@mrc-lmb.cam.ac.uk) [1]
 # *              Federico P. de Isidro Gomez (fp.deisidro@cnb.csic.es) [2]
-# *              Alberto Garcia Mena (alberto.garcia@cnb.csic.es
+# *              Alberto Garcia Mena (alberto.garcia@cnb.csic.es [2]
 # *
 # * [1] MRC Laboratory of Molecular Biology (MRC-LMB)
 # * [2] Centro Nacional de Biotecnologia, CSIC, Spain
@@ -54,7 +54,7 @@ OUT_TOMO = "outputSetOfTomograms"
 
 
 class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
-    """ Protocol for fiducial-free alignment and reconstruction for tomography. """
+    """ Protocol for fiducial-free alignment and reconstruction for tomography abailable in streaming. """
     _label = 'tilt-series align and reconstruct'
     _devStatus = BETA
     _possibleOutputs = {OUT_TS: SetOfTiltSeries,
@@ -259,13 +259,6 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
         form.addHidden(params.GPU_LIST, params.StringParam,
                        default='0', label="Choose GPU IDs")
 
-        form.addSection('Streaming')
-
-        form.addParam('dataStreaming', params.BooleanParam, default=True,
-                      label="Process data in streaming?",
-                      help="Select this option if you want tu run the protocol"
-                           "in streaming; reading for new Tilt series and"
-                           "generating outputs in streaming.")
 
     # --------------------------- INSERT steps functions ----------------------
     def stepsGeneratorStep(self):
@@ -286,21 +279,21 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                     break
             for ts in self.inputSetOfTiltSeries.get():
                 if ts.getObjId() not in self.TS_read:
-                    self.info('TS_ID input: {}\nTS_ID reading... {}\nTS_ID read: {}'.format(
+                    self.info('TS_ID input: {}\nTS_ID reading... {}\nTS_ID read: {}\n'.format(
                         listTSInput, ts.getObjId(), self.TS_read))
                     self.TS_read.append(ts.getObjId())
                     try:
                         args = (ts.getObjId(), ts.getTsId(),
                                 ts.getFirstItem().getFileName())
                         convertInput = self._insertFunctionStep(
-                            self.convertInputStep, *args)
+                            self.convertInputStep, *args, prerequisites=[])
                         runAreTomo = self._insertFunctionStep(
                             self.runAreTomoStep, *args,
                             prerequisites=[convertInput])
-                        createOutputStep = self._insertFunctionStep(self.createOutputStep, *args,
+                        createOutputS = self._insertFunctionStep(self.createOutputStep, *args,
                                                  prerequisites=[runAreTomo])
                         self._insertFunctionStep(self.closeOutputSetsStep,
-                                                 prerequisites=[createOutputStep])
+                                                 prerequisites=[createOutputS])
                     except Exception as e:
                         self.error('Error reading TS info: {}'.format(e))
                         self.error('ts.getFirstItem(): {}'.format(ts.getFirstItem()))

--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -2,6 +2,7 @@
 # *
 # * Authors:     Grigory Sharov (gsharov@mrc-lmb.cam.ac.uk) [1]
 # *              Federico P. de Isidro Gomez (fp.deisidro@cnb.csic.es) [2]
+# *              Alberto Garcia Mena (alberto.garcia@cnb.csic.es
 # *
 # * [1] MRC Laboratory of Molecular Biology (MRC-LMB)
 # * [2] Centro Nacional de Biotecnologia, CSIC, Spain
@@ -34,6 +35,7 @@ from typing import List, Literal, Tuple, Union, Optional
 import pyworkflow.protocol.params as params
 from pyworkflow.constants import BETA
 from pyworkflow.object import Set
+from pyworkflow.protocol import ProtStreamingBase
 import pyworkflow.utils as pwutils
 from pwem.protocols import EMProtocol
 from pwem.objects import Transform

--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -276,7 +276,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
             listTSInput = [ts.getObjId() for ts in self.inputSetOfTiltSeries.get()]
 
             if self.inputSetOfTiltSeries.get().isStreamOpen() == False and \
-                    self.outputSOTSList_objID == listTSInput:
+                    self.TS_read == listTSInput:
                     self.info('Input set closed and tomogram calculated for each one\n')
                     break
             for ts in self.inputSetOfTiltSeries.get():

--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -269,7 +269,6 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
         self.readingOutput()
         while True:
             listTSInput = list(self._getSetOfTiltSeries().getIdSet())
-            self.info('info: {} {}'.format(self.TS_read, listTSInput))
             if not self._getSetOfTiltSeries().isStreamOpen() and self.TS_read == listTSInput:
                 self.info('Input set closed, all items processed\n')
                 break
@@ -277,7 +276,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                 if ts.getObjId() not in self.TS_read:
                     self.info(f"TS_ID input: {listTSInput}\n"
                               f"TS_ID reading... {ts.getObjId()}\n"
-                              f"TS_ID read: {self.TS_read}\n'")
+                              f"TS_ID read: {self.TS_read}\n")
                     self.TS_read.append(ts.getObjId())
                     try:
                         args = (ts.getObjId(), ts.getTsId(),

--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -168,7 +168,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                            "A single tilt axis is first calculated followed by the determination "
                            "of how tilt axis varies over the entire tilt range. The initial "
                            "value lets users enter their estimate and AreTomo refines the "
-                           "estimate in [-3�, 3�] range.")
+                           "estimate in [-3º, 3º] range.")
 
         form.addSection(label='Extra options')
         form.addParam('doDW', params.BooleanParam, default=False,
@@ -204,7 +204,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                       condition="not useInputProt",
                       label="ROI for focused alignment",
                       help="By default AreTomo assumes the region of interest "
-                           "at the center of 0� projection image. A circular "
+                           "at the center of 0º projection image. A circular "
                            "mask is employed to down-weight the area outside "
                            "ROI during the alignment. When the structures of "
                            "interest are far away from the tilt axis, the "
@@ -214,7 +214,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                            "accuracy for the distant structures.\nHere you can "
                            "provide *a pair of x and y coordinates*, representing "
                            "the center of the region of interest.\n"
-                           "The region of interest should be selected from 0� "
+                           "The region of interest should be selected from 0º "
                            "projection image with the origin at the lower left "
                            "corner. IMOD's Pixel View is a good tool to select "
                            "the center of region of interest.")
@@ -237,7 +237,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                             "into a two-column text file, one column for x "
                             "and the other for y. Each pair defines a region "
                             "of interest (ROI). The origin of the coordinate "
-                            "system is at the image?s lower left corner.")
+                            "system is at the image's lower left corner.")
 
         line = group.addLine("Patches",
                              condition='not useInputProt and sampleType==%d' % LOCAL_MOTION_PATCHES)

--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -43,6 +43,7 @@ import time
 from tomo.protocols import ProtTomoBase
 from tomo.objects import (Tomogram, TiltSeries, TiltImage,
                           SetOfTomograms, SetOfTiltSeries)
+from pyworkflow import BETA, UPDATED, NEW, PROD
 
 from .. import Plugin
 from ..convert import getTransformationMatrix, readAlnFile
@@ -60,6 +61,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
     _possibleOutputs = {OUT_TS: SetOfTiltSeries,
                         OUT_TS_ALN: SetOfTiltSeries,
                         OUT_TOMO: SetOfTomograms}
+
 
     def __init__(self, **args):
         EMProtocol.__init__(self, **args)


### PR DESCRIPTION
How it works?

- At first the outputSetOfTiltSeries is read and if there is any calculated TiltSerie, it will be skiped
- Read each TiltSerie in the input and iterate for each one
- Concatenate the functions (convertInputStep, runAreTomoStep, createOutputStep and closeOutputSetsStep) for each TiltSerie
- If the input set is closed and there is no TiltSerie to calculate, the protocol closes

Tested in streaming by reading input from composeTS (scipion-em-tomo) that works also in streaming