### PR TITLE
Update the acquisition order in the CTFTomo objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 3.9.1:
-  Developers: the tests now use the Test Centralization Layer update and expansion of the used test set definition
-  from em-tomo v3.6.0.
+  Developers:
+   - The tests now use the Test Centralization Layer update and expansion of the used test set definition
+     from em-tomo v3.6.0.
+   - Update the acquisition order in the CTFTomo objects (field added to that class in scipion-em-tomo v3.7.0).
 3.9.0:
   Users:
     - The protocol form now present CTF-related parameters, to choose if estimate it or

--- a/aretomo/convert/dataimport.py
+++ b/aretomo/convert/dataimport.py
@@ -70,6 +70,7 @@ class AretomoCtfParser:
             if not ti.isEnabled():
                 newCtfTomo.setEnabled(False)
             newCtfTomo.setIndex(i + 1)
+            newCtfTomo.setAcquisitionOrder(ti.getAcquisitionOrder())
             output.append(newCtfTomo)
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipion-em>=3.5.0
-scipion-em-tomo>=3.6.1
+scipion-em-tomo>=3.7.0
 scipion-pyworkflow>=3.0.30
 numpy>=1.23.0


### PR DESCRIPTION
In scipion-em-tomo version 3.7.0, the acquisition order has been added to the CTFTomo to provide a robust field to match between tilt-images and CTFTomo when they come from different places, such as in Reliontomo prepare or IMOD ctf correction. It opens a way to robustly deal with re-stacked files, excluded vies, etc.