### PR TITLE
Added option to provide AlignZ value per tilt-series via text file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@
   Users:
    - Add aretomo2 1.1.2
    - Fix backwards compatibility.
+   - Add an option to specify AlignZ per TS.
   Developers:
    - The tests now use the Test Centralization Layer update and expansion of the used test set definition
      from em-tomo v3.6.0.


### PR DESCRIPTION
This PR adds an advanced option to provide a text file with thickness information (`-AlignZ` option) per tilt-series.
If a `tsId` is not present in the file, or the file is not provided, then the usual `AlignZ` parameter from the GUI is used.

An example `.txt` file looks like:
```
Position_112 700
Position_35  650
Position_18  500
Position_114 1000
```