### PR TITLE
removing non interpolated from the output

### DIFF
--- a/aretomo/tests/test_protocols_aretomo.py
+++ b/aretomo/tests/test_protocols_aretomo.py
@@ -129,15 +129,6 @@ class TestAreTomo(TestAreTomoBase):
         self.launchProtocol(prot)
 
         # CHECK THE OUTPUTS
-        # Tilt series
-        self.checkTiltSeries(getattr(prot, OUT_TS, None),
-                             expectedSetSize=self.nTiltSeries,
-                             expectedSRate=self.unbinnedSRate,
-                             expectedDimensions=self.expectedDimsTs,
-                             testAcqObj=tsAcqDict,
-                             hasAlignment=True,
-                             alignment=ALIGN_2D,
-                             anglesCount=self.nAnglesDict)
         # Interpolated TS
         self.checkTiltSeries(getattr(prot, OUT_TS_ALN, None),
                              expectedSetSize=self.nTiltSeries,
@@ -187,17 +178,6 @@ class TestAreTomo(TestAreTomoBase):
         self.launchProtocol(prot)
 
         # CHECK THE OUTPUTS
-        # Tilt series
-        self.checkTiltSeries(getattr(prot, OUT_TS, None),
-                             expectedSetSize=self.nTiltSeries,
-                             expectedSRate=self.unbinnedSRate,
-                             expectedDimensions=self.expectedDimsTs,
-                             testAcqObj=tsAcqDict,
-                             hasAlignment=True,
-                             alignment=ALIGN_2D,
-                             anglesCount=self.nAnglesDict,
-                             excludedViewsDict=exludedViews)
-
         # Interpolated TS
         self.checkTiltSeries(getattr(prot, OUT_TS_ALN, None),
                              expectedSetSize=self.nTiltSeries,
@@ -234,15 +214,14 @@ class TestAreTomo(TestAreTomoBase):
         self.launchProtocol(prot)
 
         # CHECK THE OUTPUTS
-        # Tilt series
+        # Interpolated Tilt series
         self.checkTiltSeries(getattr(prot, OUT_TS, None),
                              expectedSetSize=self.nTiltSeries,
                              expectedSRate=self.unbinnedSRate,
-                             expectedDimensions=self.expectedDimsTs,
-                             testAcqObj=tsAcqDict,
-                             hasAlignment=True,
-                             alignment=ALIGN_2D,
-                             anglesCount=self.nAnglesDict)
+                             expectedDimensions=self.expectedDimsTsInterp,
+                             testAcqObj=tsAcqDictInterp,
+                             anglesCount=self.nAnglesDict,
+                             isInterpolated=True)
 
         # CTFs
         self._checkCTFs(getattr(prot, OUT_CTFS, None))


### PR DESCRIPTION
The non-interpolated output cannot be properly used in later processin steps

In a conversation with the developer, he thinks the interpolated output has enoght quality to work with it, and should be used.

The reason to remove the non-interpolated is the following one:

* The alignment is not correct, the in plane rotation per image is not provided by aretomo. Aretomo provides the same in-plane rotation for all tilt images. This in-plane rotation is the tilt axis orientation.


More modifications should be addressed in the future, perhaps in aretomo3. The current PR does not fix them, but enhance the user experience of aretomo:

* Currently, the CTF correction cannot be carried out. CTF should be estimated with the non-interpolated, but applied after the alignment. If the output is aligned the astigmatism is not rotated. If the CTF is corrected before aligning, the problem is fixed, but then the output will show +ali, !interp. This is because, the CTF correction applies the alignment. So this situation is misleading for the users.

* Perhaps, alignment, CTF and reconstruction should be independent protocols. This would be very versatile and more user friendly
