### PR TITLE
Removed extra indentation level from sleep in stepsGeneratorStep

### DIFF
--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -337,7 +337,7 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                     except Exception as e:
                         self.error(f'Error reading TS info: {e}')
                         self.error(f'ts.getFirstItem(): {ts.getFirstItem()}')
-                time.sleep(10)
+            time.sleep(10)
 
     # --------------------------- STEPS functions -----------------------------
     def convertInputStep(self, tsId: str, tsFn: str):


### PR DESCRIPTION
An extra indentation on a sleep function call was slowing down step generation in `stepsGeneratorStep`. Furthermore, in a streaming environment, this would quadratically increase processing time, as the sleep command is called regardless of the TS is processed or not.