### PR TITLE
Streaming fixed: updates correctly the new input

### DIFF
--- a/aretomo/protocols/protocol_aretomo.py
+++ b/aretomo/protocols/protocol_aretomo.py
@@ -345,8 +345,6 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
             for ts in self._getSetOfTiltSeries():
                 if ts.getTsId() not in self.TS_read:
                     tsId = ts.getTsId()
-                    self.info(f"Steps created for TS_ID: {tsId}")
-                    self.TS_read.append(tsId)
                     try:
                         args = (tsId, ts.getFirstItem().getFileName())
                         convertInput = self._insertFunctionStep(self.convertInputStep, *args,
@@ -359,11 +357,15 @@ class ProtAreTomoAlignRecon(EMProtocol, ProtTomoBase, ProtStreamingBase):
                                                                  prerequisites=[runAreTomo],
                                                                  needsGPU=False)
                         closeSetStepDeps.append(createOutputS)
-
+                        self.info(f"Steps created for TS_ID: {tsId}")
+                        self.TS_read.append(tsId)
                     except Exception as e:
                         self.error(f'Error reading TS info: {e}')
                         self.error(f'ts.getFirstItem(): {ts.getFirstItem()}')
+
             time.sleep(10)
+            if self._getSetOfTiltSeries().isStreamOpen():
+                self._getSetOfTiltSeries().loadAllProperties() # refresh status for the streaming
 
     # --------------------------- STEPS functions -----------------------------
     def convertInputStep(self, tsId: str, tsFn: str):


### PR DESCRIPTION
The streaming was not working properly, and we encountered two main issues related to how we update the input set:
- At some point, no new steps were introduced.
- When all the tilt-series were processed, the process did not stop.
